### PR TITLE
Polyfilling array.prototype.flat() to support Node < v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "devDependencies": {
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
+    "array-flat-polyfill": "^1.0.1",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.6.2",
@@ -29,6 +30,13 @@
       "^.+\\.ts?$": "ts-jest"
     },
     "testEnvironment": "node",
-    "moduleFileExtensions": ["ts", "tsx", "js", "jsx", "json", "node"]
+    "moduleFileExtensions": [
+      "ts",
+      "tsx",
+      "js",
+      "jsx",
+      "json",
+      "node"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,13 +13,13 @@
   "devDependencies": {
     "@types/jest": "^25.1.3",
     "@types/node": "^13.7.7",
-    "array-flat-polyfill": "^1.0.1",
     "jest": "^25.1.0",
     "ts-jest": "^25.2.1",
     "ts-node": "^8.6.2",
     "typescript": "^3.8.3"
   },
   "dependencies": {
+    "array-flat-polyfill": "^1.0.1",
     "chalk": "^3.0.0",
     "conf": "^6.2.1",
     "enquirer": "^2.3.4",

--- a/src/commands/open.ts
+++ b/src/commands/open.ts
@@ -5,6 +5,7 @@ import { promisify } from 'util';
 import { prompt } from 'enquirer';
 import { exec } from 'child_process';
 import * as fs from '../functions/fs';
+import 'array-flat-polyfill';
 
 const execPromise = promisify(exec);
 


### PR DESCRIPTION
Adds `Array.prototype.flat()` which is not present in Node versions < 12.
Fixes #2 